### PR TITLE
Microos is suse

### DIFF
--- a/packages/pkg-deps.json
+++ b/packages/pkg-deps.json
@@ -58,12 +58,14 @@
    },
    "suse" : {
       "renames" : {
+         "jinja2" : "python3-Jinja2",
+         "pyyaml" : "python3-PyYAML"
       },
       "build-requires" : [
          "fdupes",
          "filesystem",
-         "python-devel",
-         "python-setuptools"
+         "python3-devel",
+         "python3-setuptools"
       ],
       "requires" : [
          "iproute2",

--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -121,7 +121,9 @@ class TestOpenNebulaDataSource(CiTestCase):
             util.find_devs_with = lambda n: []  # type: ignore
             populate_context_dir(self.seed_dir, {"KEY1": "val1"})
             dsrc = self.ds(sys_cfg=self.sys_cfg, distro=None, paths=self.paths)
-            ret = dsrc.get_data()
+            with mock.patch(DS_PATH + ".pwd.getpwnam") as getpwnam:
+                ret = dsrc.get_data()
+            self.assertEqual([mock.call("nobody")], getpwnam.call_args_list)
             self.assertTrue(ret)
         finally:
             util.find_devs_with = orig_find_devs_with

--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -9,8 +9,9 @@ try:
     from argparse import ArgumentParser
 except ImportError:
     raise RuntimeError(
-        'Could not import argparse. Please install python3-argparse '
-        'package to continue')
+        "Could not import argparse. Please install python3-argparse "
+        "package to continue"
+    )
 
 import json
 import os
@@ -18,29 +19,30 @@ import re
 import subprocess
 import sys
 
-DEFAULT_REQUIREMENTS = 'requirements.txt'
+DEFAULT_REQUIREMENTS = "requirements.txt"
 
 # Map the appropriate package dir needed for each distro choice
 DISTRO_PKG_TYPE_MAP = {
-    'centos': 'redhat',
-    'eurolinux': 'redhat',
-    'miraclelinux': 'redhat',
-    'rocky': 'redhat',
-    'redhat': 'redhat',
-    'debian': 'debian',
-    'ubuntu': 'debian',
-    'opensuse': 'suse',
-    'opensuse-leap': 'suse',
-    'opensuse-microos': 'suse',
-    'opensuse-tumbleweed': 'suse',
-    'sle_hpc': 'suse',
-    'sle-micro': 'suse',
-    'sles': 'suse',
-    'suse': 'suse'
+    "centos": "redhat",
+    "eurolinux": "redhat",
+    "miraclelinux": "redhat",
+    "rocky": "redhat",
+    "redhat": "redhat",
+    "debian": "debian",
+    "ubuntu": "debian",
+    "opensuse": "suse",
+    "opensuse-leap": "suse",
+    "opensuse-microos": "suse",
+    "opensuse-tumbleweed": "suse",
+    "sle_hpc": "suse",
+    "sle-micro": "suse",
+    "sles": "suse",
+    "suse": "suse",
 }
 
 MAYBE_RELIABLE_YUM_INSTALL = [
-    'sh', '-c',
+    "sh",
+    "-c",
     """
     error() { echo "$@" 1>&2; }
     configure_repos_for_proxy_use() {
@@ -67,42 +69,37 @@ MAYBE_RELIABLE_YUM_INSTALL = [
     yum install --cacheonly --assumeyes "$@"
     configure_repos_for_proxy_use
     """,
-    'reliable-yum-install']
+    "reliable-yum-install",
+]
 
 ZYPPER_INSTALL = [
-    'zypper', '--non-interactive', '--gpg-auto-import-keys', 'install',
-    '--auto-agree-with-licenses']
+    "zypper",
+    "--non-interactive",
+    "--gpg-auto-import-keys",
+    "install",
+    "--auto-agree-with-licenses",
+]
 
-DRY_DISTRO_INSTALL_PKG_CMD = {
-    'rocky': ['yum', 'install', '--assumeyes'],
-    'centos': ['yum', 'install', '--assumeyes'],
-    'eurolinux': ['yum', 'install', '--assumeyes'],
-    'miraclelinux': ['yum', 'install', '--assumeyes'],
-    'redhat': ['yum', 'install', '--assumeyes'],
+DRYRUN_DISTRO_INSTALL_PKG_CMD = {
+    "redhat": ["yum", "install", "--assumeyes"],
 }
 
 DISTRO_INSTALL_PKG_CMD = {
-    'rocky': MAYBE_RELIABLE_YUM_INSTALL,
-    'eurolinux': MAYBE_RELIABLE_YUM_INSTALL,
-    'miraclelinux': MAYBE_RELIABLE_YUM_INSTALL,
-    'centos': MAYBE_RELIABLE_YUM_INSTALL,
-    'redhat': MAYBE_RELIABLE_YUM_INSTALL,
-    'debian': ['apt', 'install', '-y'],
-    'ubuntu': ['apt', 'install', '-y'],
-    'opensuse': ZYPPER_INSTALL,
-    'suse': ZYPPER_INSTALL,
+    "redhat": MAYBE_RELIABLE_YUM_INSTALL,
+    "debian": ["apt", "install", "-y"],
+    "suse": ZYPPER_INSTALL,
 }
-
 
 # List of base system packages required to enable ci automation
 CI_SYSTEM_BASE_PKGS = {
-    'common': ['make', 'sudo', 'tar'],
-    'eurolinux': ['python3-tox'],
-    'miraclelinux': ['python3-tox'],
-    'redhat': ['python3-tox'],
-    'centos': ['python3-tox'],
-    'ubuntu': ['devscripts', 'python3-dev', 'libssl-dev', 'tox', 'sbuild'],
-    'debian': ['devscripts', 'python3-dev', 'libssl-dev', 'tox', 'sbuild']}
+    "common": ["make", "sudo", "tar"],
+    "eurolinux": ["python3-tox"],
+    "miraclelinux": ["python3-tox"],
+    "redhat": ["python3-tox"],
+    "centos": ["python3-tox"],
+    "ubuntu": ["devscripts", "python3-dev", "libssl-dev", "tox", "sbuild"],
+    "debian": ["devscripts", "python3-dev", "libssl-dev", "tox", "sbuild"],
+}
 
 
 # JSON definition of distro-specific package dependencies
@@ -113,36 +110,70 @@ def get_parser():
     """Return an argument parser for this command."""
     parser = ArgumentParser(description=__doc__)
     parser.add_argument(
-        '-r', '--requirements-file', type=str, dest='req_files',
-        action='append', default=None,
-        help='pip-style requirements file [default=%s]' % DEFAULT_REQUIREMENTS)
+        "-r",
+        "--requirements-file",
+        type=str,
+        dest="req_files",
+        action="append",
+        default=None,
+        help="pip-style requirements file [default=%s]" % DEFAULT_REQUIREMENTS,
+    )
     parser.add_argument(
-        '-d', '--distro', type=str, choices=DISTRO_PKG_TYPE_MAP.keys(),
-        help='The name of the distro to generate package deps for.')
+        "-d",
+        "--distro",
+        type=str,
+        choices=DISTRO_PKG_TYPE_MAP.keys(),
+        help="The name of the distro to generate package deps for.",
+    )
     deptype = parser.add_mutually_exclusive_group()
     deptype.add_argument(
-        '-R', '--runtime-requires', action='store_true', default=False,
-        dest='runtime_requires',
-        help='Print only runtime required packages')
+        "-R",
+        "--runtime-requires",
+        action="store_true",
+        default=False,
+        dest="runtime_requires",
+        help="Print only runtime required packages",
+    )
     deptype.add_argument(
-        '-b', '--build-requires', action='store_true', default=False,
-        dest='build_requires', help='Print only buildtime required packages')
+        "-b",
+        "--build-requires",
+        action="store_true",
+        default=False,
+        dest="build_requires",
+        help="Print only buildtime required packages",
+    )
     parser.add_argument(
-        '--dry-run', action='store_true', default=False, dest='dry_run',
-        help='Dry run the install, making no package changes.')
+        "--dry-run",
+        action="store_true",
+        default=False,
+        dest="dry_run",
+        help="Dry run the install, making no package changes.",
+    )
     parser.add_argument(
-        '-s', '--system-pkg-names', action='store_true', default=False,
-        dest='system_pkg_names',
-        help='Generate distribution package names (python3-pkgname).')
+        "-s",
+        "--system-pkg-names",
+        action="store_true",
+        default=False,
+        dest="system_pkg_names",
+        help="Generate distribution package names (python3-pkgname).",
+    )
     parser.add_argument(
-        '-i', '--install', action='store_true', default=False,
-        dest='install',
-        help='When specified, install the required system packages.')
+        "-i",
+        "--install",
+        action="store_true",
+        default=False,
+        dest="install",
+        help="When specified, install the required system packages.",
+    )
     parser.add_argument(
-        '-t', '--test-distro', action='store_true', default=False,
-        dest='test_distro',
-        help='Additionally install continuous integration system packages '
-             'required for build and test automation.')
+        "-t",
+        "--test-distro",
+        action="store_true",
+        default=False,
+        dest="test_distro",
+        help="Additionally install continuous integration system packages "
+        "required for build and test automation.",
+    )
     return parser
 
 
@@ -156,7 +187,7 @@ def get_package_deps_from_json(topdir, distro):
     @return: Dict containing "requires", "build-requires" and "rename" lists
         for a given distribution.
     """
-    with open(os.path.join(topdir, DISTRO_PKG_DEPS_PATH), 'r') as stream:
+    with open(os.path.join(topdir, DISTRO_PKG_DEPS_PATH), "r") as stream:
         deps = json.loads(stream.read())
     if distro is None:
         return {}
@@ -176,11 +207,11 @@ def parse_pip_requirements(requirements_path):
                 continue
 
             # remove pip-style markers
-            dep = line.split(';')[0]
+            dep = line.split(";")[0]
 
             # remove version requirements
-            if re.search('[>=.<]+', dep):
-                dep_names.append(re.split(r'[>=.<]+', dep)[0].strip())
+            if re.search("[>=.<]+", dep):
+                dep_names.append(re.split(r"[>=.<]+", dep)[0].strip())
             else:
                 dep_names.append(dep)
     return dep_names
@@ -203,16 +234,15 @@ def translate_pip_to_system_pkg(pip_requires, renames):
         if rename:
             translated_names.append(rename)
         else:
-            translated_names.append(
-                standard_pkg_name.format(prefix, pip_name))
+            translated_names.append(standard_pkg_name.format(prefix, pip_name))
     return translated_names
 
 
 def main(distro):
     parser = get_parser()
     args = parser.parse_args()
-    if 'CLOUD_INIT_TOP_D' in os.environ:
-        topd = os.path.realpath(os.environ.get('CLOUD_INIT_TOP_D'))
+    if "CLOUD_INIT_TOP_D" in os.environ:
+        topd = os.path.realpath(os.environ.get("CLOUD_INIT_TOP_D"))
     else:
         topd = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
@@ -221,45 +251,52 @@ def main(distro):
         if args.req_files:
             sys.stderr.write(
                 "Parameter --test-distro overrides --requirements-file. Use "
-                "one or the other.\n")
+                "one or the other.\n"
+            )
             sys.exit(1)
-        args.req_files = [os.path.join(topd, DEFAULT_REQUIREMENTS),
-                          os.path.join(topd, 'test-' + DEFAULT_REQUIREMENTS)]
+        args.req_files = [
+            os.path.join(topd, DEFAULT_REQUIREMENTS),
+            os.path.join(topd, "test-" + DEFAULT_REQUIREMENTS),
+        ]
         args.install = True
     if args.req_files is None:
         args.req_files = [os.path.join(topd, DEFAULT_REQUIREMENTS)]
         if not os.path.isfile(args.req_files[0]):
-            sys.stderr.write("Unable to locate '%s' file that should "
-                             "exist in cloud-init root directory." %
-                             args.req_files[0])
+            sys.stderr.write(
+                "Unable to locate '%s' file that should "
+                "exist in cloud-init root directory." % args.req_files[0]
+            )
             sys.exit(1)
 
     bad_files = [r for r in args.req_files if not os.path.isfile(r)]
     if bad_files:
         sys.stderr.write(
-            "Unable to find requirements files: %s\n" % ','.join(bad_files))
+            "Unable to find requirements files: %s\n" % ",".join(bad_files)
+        )
         sys.exit(1)
 
     pip_pkg_names = set()
     for req_path in args.req_files:
         pip_pkg_names.update(set(parse_pip_requirements(req_path)))
     deps_from_json = get_package_deps_from_json(topd, args.distro)
-    renames = deps_from_json.get('renames', {})
-    translated_pip_names = translate_pip_to_system_pkg(
-        pip_pkg_names, renames)
+    renames = deps_from_json.get("renames", {})
+    translated_pip_names = translate_pip_to_system_pkg(pip_pkg_names, renames)
     all_deps = []
     select_requires = [args.build_requires, args.runtime_requires]
     if args.distro:
         if not any(select_requires):
             all_deps.extend(
-                translated_pip_names + deps_from_json['requires'] +
-                deps_from_json['build-requires'])
+                translated_pip_names
+                + deps_from_json["requires"]
+                + deps_from_json["build-requires"]
+            )
         else:
             if args.build_requires:
-                all_deps.extend(deps_from_json['build-requires'])
+                all_deps.extend(deps_from_json["build-requires"])
             else:
                 all_deps.extend(
-                    translated_pip_names + deps_from_json['requires'])
+                    translated_pip_names + deps_from_json["requires"]
+                )
     else:
         if args.system_pkg_names:
             all_deps = translated_pip_names
@@ -269,33 +306,45 @@ def main(distro):
     if args.install:
         pkg_install(all_deps, args.distro, args.test_distro, args.dry_run)
     else:
-        print('\n'.join(all_deps))
+        print("\n".join(all_deps))
 
 
 def pkg_install(pkg_list, distro, test_distro=False, dry_run=False):
     """Install a list of packages using the DISTRO_INSTALL_PKG_CMD."""
     if test_distro:
-        pkg_list = list(pkg_list) + CI_SYSTEM_BASE_PKGS['common']
+        pkg_list = list(pkg_list) + CI_SYSTEM_BASE_PKGS["common"]
         distro_base_pkgs = CI_SYSTEM_BASE_PKGS.get(distro, [])
         pkg_list += distro_base_pkgs
-    print('Installing deps: {0}{1}'.format(
-          '(dryrun)' if dry_run else '', ' '.join(pkg_list)))
+    print(
+        "Installing deps: {0}{1}".format(
+            "(dryrun)" if dry_run else "", " ".join(pkg_list)
+        )
+    )
     install_cmd = []
     if dry_run:
-        install_cmd.append('echo')
+        install_cmd.append("echo")
     if os.geteuid() != 0:
-        install_cmd.append('sudo')
+        install_cmd.append("sudo")
 
-    cmd = DISTRO_INSTALL_PKG_CMD[distro]
-    if dry_run and distro in DRY_DISTRO_INSTALL_PKG_CMD:
-        cmd = DRY_DISTRO_INSTALL_PKG_CMD[distro]
+    distro_family = DISTRO_PKG_TYPE_MAP[distro]
+    if dry_run and distro_family in DRYRUN_DISTRO_INSTALL_PKG_CMD:
+        cmd = DRYRUN_DISTRO_INSTALL_PKG_CMD[distro_family]
+    else:
+        cmd = DISTRO_INSTALL_PKG_CMD[distro_family]
     install_cmd.extend(cmd)
 
-    if distro in ['centos', 'redhat', 'rocky', 'eurolinux']:
+    if distro in ["centos", "redhat", "rocky", "eurolinux"]:
         # CentOS and Redhat need epel-release to access oauthlib and jsonschema
-        subprocess.check_call(install_cmd + ['epel-release'])
-    if distro in ['suse', 'opensuse', 'redhat', 'rocky', 'centos', 'eurolinux']:
-        pkg_list.append('rpm-build')
+        subprocess.check_call(install_cmd + ["epel-release"])
+    if distro in [
+        "suse",
+        "opensuse",
+        "redhat",
+        "rocky",
+        "centos",
+        "eurolinux",
+    ]:
+        pkg_list.append("rpm-build")
     subprocess.check_call(install_cmd + pkg_list)
 
 

--- a/tools/run-container
+++ b/tools/run-container
@@ -24,7 +24,7 @@ Usage: ${0##*/} [ options ] [images:]image-ref
     To see images available, run 'lxc image list images:'
     Example input:
        centos/7
-       opensuse/42.3
+       opensuse/15.4
        debian/10
 
     options:
@@ -249,7 +249,7 @@ install_packages() {
     get_os_info || return
     case "$OS_NAME" in
         centos|rocky*) yum_install "$@";;
-        opensuse) zypper_install "$@";;
+        opensuse*) zypper_install "$@";;
         debian|ubuntu) apt_install "$@";;
         *) error "Do not know how to install packages on ${OS_NAME}";
            return 1;;
@@ -497,8 +497,8 @@ main() {
 
     local build_pkg="" build_srcpkg="" pkg_ext="" distflag=""
     case "$OS_NAME" in
-        centos|rocky) distflag="--distro=redhat";;
-        opensuse) distflag="--distro=suse";;
+        centos|rocky*) distflag="--distro=redhat";;
+        opensuse*) distflag="--distro=suse";;
     esac
 
     case "$OS_NAME" in
@@ -506,7 +506,7 @@ main() {
             build_pkg="./packages/bddeb -d" 
             build_srcpkg="./packages/bddeb -S -d"
             pkg_ext=".deb";;
-        centos|opensuse|rocky)
+        centos|opensuse*|rocky*)
             build_pkg="./packages/brpm $distflag"
             build_srcpkg="./packages/brpm $distflag --srpm"
             pkg_ext=".rpm";;


### PR DESCRIPTION
```
*    tools: run-container read-deps less duplication using OS family
    
    Package maintenance operations are the same across OS families:
     - Debian/Ubuntu use apt
     - RedHat, CentOS, RockyLinux use yum
     - opensuse* use zypper
    
    Consolidate package operations based on OS family instead of
    distro flavor to cut down on duplication of command definitions.
    
    formatting with black

*    tools: read-dependencies fix jinja2 and PyYAML pkg aliases for opensuse


*   tests: mock leaked pwd.getpwnam call for opensuse
    
    By default opensuse doesn't have a 'nobody' user.
    Mock this test to assert the default of nobody user
    is queried.
```
